### PR TITLE
update request method

### DIFF
--- a/client/FurryGetter.js
+++ b/client/FurryGetter.js
@@ -9,16 +9,15 @@ class FurryGetter {
     
     getFurry(limit, tags, auth) {
         var options = {
-            method: 'POST',
-            uri: 'https://e621.net/post/index.json',
-            body: {
+            method: 'GET',
+            uri: 'https://e621.net/posts.json',
+            qs: {
                 "limit": limit,
                 "tags": tags
             },
             headers: {
                 "User-Agent": "node-e621/1.0 " + auth
-            },
-            json: true // Automatically stringifies the body to JSON 
+            }
         };
         return rp(options).then((e621data) => { return (e621data) })
     }


### PR DESCRIPTION
e621 updated their API so now fetching posts is done with GET and query params instead of POST